### PR TITLE
escaped the api url

### DIFF
--- a/lib/foursquare.rb
+++ b/lib/foursquare.rb
@@ -107,6 +107,7 @@ module Foursquare
       url = BASE_URL + '/' + method_name.split('.').join('/')
       url += ".#{FORMAT}"
       url += "?#{params}" if params
+      url = URI.escape(url)
       url
     end
     


### PR DESCRIPTION
search queries with a space in the search term were failing because the space was not getting escaped in the url string. 

e.g. 
f_client.venues :geolat => lat, :geolong => lng, :l => 1, :q = "Coffee Bean" 
