### PR TITLE
Use https as HTTP is throwing a 301 redirect to point at the https version

### DIFF
--- a/lib/foursquare.rb
+++ b/lib/foursquare.rb
@@ -16,7 +16,7 @@ module Foursquare
     def consumer
       return @consumer if @consumer
       @consumer = ::OAuth::Consumer.new(@consumer_token, @consumer_secret, {
-        :site               => "http://foursquare.com",
+        :site               => "https://foursquare.com",
         :scheme             => :header,
         :http_method        => :post,
         :request_token_path => "/oauth/request_token",
@@ -57,7 +57,7 @@ module Foursquare
   end
   
   class Base
-    BASE_URL = 'http://api.foursquare.com/v1'
+    BASE_URL = 'https://api.foursquare.com/v1'
     FORMAT = 'json'
     
     attr_accessor :oauth


### PR DESCRIPTION
Attempts to access the API over HTTP are returning a 301 redirect to the secure HTTPS version.

```
curl -d "" -i http://api.foursquare.com/oauth/request_token
HTTP/1.1 301 Moved Permanently
Content-Type: text/html
Date: Wed, 06 Apr 2011 12:56:37 GMT
Location: https://api.foursquare.com/oauth/request_token
Server: nginx/0.8.52
Content-Length: 185
Connection: keep-alive

<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/0.8.52</center>
</body>
</html>
```

This triggers an Exception in the library. This pull request updates the URLS to use the HTTPS version.
